### PR TITLE
Ethtool is used only in linux kernels, disabling it for !linux archs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ettercap (1:0.8.0-11) unstable; urgency=medium
+
+  * Removing ethtool as b-d for non linux kernels.
+
+ -- Gianfranco Costamagna <costamagnagianfranco@yahoo.it>  Tue, 11 Mar 2014 09:52:02 +0100
+
 ettercap (1:0.8.0-10) unstable; urgency=medium
 
   [ Gianfranco Costamagna ]

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: Barak A. Pearlmutter <bap@debian.org>
 Uploaders: Murat Demirten <murat@debian.org>,
-	   Gianfranco Costamagna <costamagnagianfranco@yahoo.it>
+ Gianfranco Costamagna <costamagnagianfranco@yahoo.it>
 Build-Depends: debhelper (>= 9),
  cmake,
  chrpath,
@@ -26,7 +26,8 @@ Vcs-Browser: http://github.com/barak/ettercap
 
 Package: ettercap-common
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends},
+ ethtool [linux-any]
 Recommends: ettercap-graphical | ettercap-text-only
 Replaces: ettercap-plugins
 Conflicts: ettercap-plugins, ettercap (<= 1:0.7.3)
@@ -53,8 +54,7 @@ Description: Multipurpose sniffer/interceptor/logger for switched LAN
 
 Package: ettercap-text-only
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, ettercap-common (= ${binary:Version}),
-	ethtool
+Depends: ${shlibs:Depends}, ${misc:Depends}, ettercap-common (= ${binary:Version})
 Replaces: ettercap-gtk, ettercap-graphical, ettercap
 Conflicts: ettercap-gtk, ettercap-graphical, ettercap (<= 1:0.7.3)
 Provides: ettercap
@@ -79,7 +79,7 @@ Description: Ettercap console-mode executable
 Package: ettercap-graphical
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, ettercap-common (= ${binary:Version}),
-	ethtool, policykit-1
+ policykit-1
 Replaces: ettercap-gtk, ettercap-text-only, ettercap, ettercap-common
 Conflicts: ettercap-gtk, ettercap-text-only, ettercap (<= 1:0.7.3)
 Provides: ettercap
@@ -107,7 +107,7 @@ Section: debug
 Priority: extra
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
-	 ettercap-common (= ${binary:Version}),
-	 ettercap-graphical (= ${binary:Version}) | ettercap-text-only (= ${binary:Version})
+ ettercap-common (= ${binary:Version}),
+ ettercap-graphical (= ${binary:Version}) | ettercap-text-only (= ${binary:Version})
 Description: Debug symbols for Ettercap.
  Ettercap runtime debug symbols.


### PR DESCRIPTION
Sorry Barak, that one should really be the last upload.

Tried on both amd64 and kfreebsd-i386, now the package should install flawlessly and not bothering anymore about missing ethtool stuff.

I also uploaded the -11 debian tag.
